### PR TITLE
fix: check map.style before accessing properties

### DIFF
--- a/src/components/RLayer/RLayer.tsx
+++ b/src/components/RLayer/RLayer.tsx
@@ -207,7 +207,7 @@ export const RLayer = memo(
     useEffect(() => {
       map.on("styledata", reRender);
 
-      if (map.style._loaded) {
+      if (map.style && map.style._loaded) {
         // in case layer is loaded between first render and useEffect call
         // like RSource
         reRender();

--- a/src/components/RSource/RSource.tsx
+++ b/src/components/RSource/RSource.tsx
@@ -153,7 +153,7 @@ export const RSource = memo(
        */
       map.on("styledata", reRender);
 
-      if (map.style._loaded) {
+      if (map.style && map.style._loaded) {
         // in case style is loaded between first render and useEffect call
         // our styledata listener arrives too late we have to force a new
         // render to add our source

--- a/src/components/RTerrain/RTerrain.tsx
+++ b/src/components/RTerrain/RTerrain.tsx
@@ -19,7 +19,7 @@ export const RTerrain = (props: RTerrainProps) => {
   useEffect(() => {
     map.on("styledata", reRender);
 
-    if (map.style._loaded) {
+    if (map.style && map.style._loaded) {
       // in case layer is loaded between first render and useEffect call
       // like RSource
       reRender();


### PR DESCRIPTION
Fixes #5.

I couldn’t create a reproduction, but I tested this in my setup, and it worked for me!